### PR TITLE
issue about sidebar.md not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ I have fixed all the issues I met. If you find any issues, please report them to
 
 ### 1.2.0
 
-The scroll will be in the wrong position when you save the markdown file if the current markdown file can't be found in the sidebar. I find the reason is that Docsify won't execute the function `hook.ready` if the Markdown file is not in the sidebar. So you'd better add the markdown file to the sidebar first before writing the Markdown file with joy.
+fix: issue
 
-> fixed, the problem is that I don't respond 404 to the client if the file is not found.
+see more detail at https://github.com/dzylikecode/VSCodeExt-docsify-Preview/pull/11
 
 ### 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,13 @@ If you want to paste images in markdown, welcome to use my other plugin:[md-past
 
 I have fixed all the issues I met. If you find any issues, please report them to [issue](https://github.com/dzylikecode/VSCodeExt-docsify-Preview/issues)
 
+## Release Notes
+
+### 1.2.0
+
 The scroll will be in the wrong position when you save the markdown file if the current markdown file can't be found in the sidebar. I find the reason is that Docsify won't execute the function `hook.ready` if the Markdown file is not in the sidebar. So you'd better add the markdown file to the sidebar first before writing the Markdown file with joy.
 
-## Release Notes
+> fixed, the problem is that I don't respond 404 to the client if the file is not found.
 
 ### 1.1.0
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "activationEvents": [
     "onLanguage:markdown"
   ],
-  "main": "./out/extension.js",
+  "main": "./src/extension.js",
   "contributes": {
     "configuration": {
       "title": "docsify Preview",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "docsify-preview",
   "displayName": "docsify-Preview",
   "description": "write docs easily with docsify",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "engines": {
     "vscode": "^1.71.0"
   },
@@ -34,7 +34,7 @@
   "activationEvents": [
     "onLanguage:markdown"
   ],
-  "main": "./src/extension.js",
+  "main": "./out/extension.js",
   "contributes": {
     "configuration": {
       "title": "docsify Preview",

--- a/src/server/httpServer.js
+++ b/src/server/httpServer.js
@@ -43,6 +43,12 @@ let httpServer = {
           if (fs.existsSync(filePath)) {
             response.sendFile(filePath);
           } else {
+            response.status(404).send({
+              error: {
+                status: 404,
+                message: "File not found: " + filePath,
+              },
+            });
             console.log("File not found: " + filePath);
           }
         });


### PR DESCRIPTION
## problem 1

The scroll will be in the wrong position when you save the markdown file if the current markdown file can't be found in the sidebar. I find the reason is that Docsify won't execute the function `hook.ready` if the Markdown file is not in the sidebar. So you'd better add the markdown file to the sidebar first before writing the Markdown file with joy.

## problem 2

`docsify-plugin-runkit` doesn't work if `sidebar.md` doesn't exist in the same directory.