### PR TITLE
fixed: failed to open an external link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+- 1.6.0
+
+  [fixed: failed to open an external link](https://github.com/dzylikecode/VSCodeExt-docsify-Preview/pull/15)
+
 - Initial release

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ If you want to paste images in markdown, welcome to use my other plugin:[md-past
 
 ## Known Issues
 
+You may open the duplicate tab in the browser if click the external link.
+
 If you find any issues, please report them to [issue](https://github.com/dzylikecode/VSCodeExt-docsify-Preview/issues)
 
 ## Release Notes
@@ -77,7 +79,7 @@ If you find any issues, please report them to [issue](https://github.com/dzylike
 
 fixed: failed to open an external link
 
-> Now you can open the external link in the preview, and then it will be opened in the browser.
+> Now you can open the external link in the preview, and then it will be opened in the browser. But the problem is that you may open the duplicate tab in the browser. I will try to fix it in the future.
 
 ### 1.5.0
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ If you want to paste images in markdown, welcome to use my other plugin:[md-past
 
 ## Known Issues
 
-You should open the preview in the browser if click the external link in the preview. The reason why it can't be opened inside the preview is the limitation of Webview.
-
-> may be I can try open it in the browser.
-
 If you find any issues, please report them to [issue](https://github.com/dzylikecode/VSCodeExt-docsify-Preview/issues)
 
 ## Release Notes
+
+### 1.6.0
+
+fixed: failed to open an external link
+
+> Now you can open the external link in the preview, and then it will be opened in the browser.
 
 ### 1.5.0
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you want to paste images in markdown, welcome to use my other plugin:[md-past
 
 ## Known Issues
 
-You may open the duplicate tab in the browser if click the external link.
+You may open the duplicate tab in the browser if clicking the external link.
 
 If you find any issues, please report them to [issue](https://github.com/dzylikecode/VSCodeExt-docsify-Preview/issues)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you want to paste images in markdown, welcome to use my other plugin:[md-past
 
 ## Known Issues
 
-You should open the preview in the browser if click the external link in the preview. The reason why it can't open it inside the preview is the limitation of Webview.
+You should open the preview in the browser if click the external link in the preview. The reason why it can't be opened inside the preview is the limitation of Webview.
 
 > may be I can try open it in the browser.
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "activationEvents": [
     "onLanguage:markdown"
   ],
-  "main": "./out/extension.js",
+  "main": "./src/extension.js",
   "contributes": {
     "configuration": {
       "title": "docsify Preview",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "docsify-preview",
   "displayName": "docsify-Preview",
   "description": "write docs easily with docsify",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "engines": {
     "vscode": "^1.71.0"
   },
@@ -34,7 +34,7 @@
   "activationEvents": [
     "onLanguage:markdown"
   ],
-  "main": "./src/extension.js",
+  "main": "./out/extension.js",
   "contributes": {
     "configuration": {
       "title": "docsify Preview",

--- a/src/main.js
+++ b/src/main.js
@@ -67,6 +67,8 @@ async function main(context, disposable) {
       );
     } else if (message.command == "closePreview") {
       server.close();
+    } else if (message.command == "openLink") {
+      vscode.env.openExternal(message.url);
     }
     return;
     function goHere(url, linePercent) {

--- a/src/server/assets/js/main.js
+++ b/src/server/assets/js/main.js
@@ -49,6 +49,9 @@ window.addEventListener("message", (event) => {
     case "hideContextMenu":
       hideContextMenu();
       break;
+    case "openLink":
+      vscode.postMessage(message);
+      break;
   }
 });
 

--- a/src/server/listener/injected.html
+++ b/src/server/listener/injected.html
@@ -99,6 +99,23 @@
             }
           }
         });
+        hook.doneEach(() => {
+          openBlankLink();
+          return;
+          function openBlankLink() {
+            document.querySelectorAll("a[target='_blank']").forEach((link) => {
+              link.addEventListener("click", (e) => {
+                window.parent.window.postMessage(
+                  {
+                    command: "openLink",
+                    url: link.href,
+                  },
+                  "*"
+                );
+              });
+            });
+          }
+        });
         hook.ready(() => {
           // this why I can't scroll window directly
           restoreScrollState();


### PR DESCRIPTION
## situation

You should open the preview in the browser if clicking the external link in the preview. The reason why it can't be opened inside the preview is the limitation of Webview.

## solution

attach a listener to the external link to open the external link in the default browser